### PR TITLE
Update reported Graph-RCNN numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ We have created a branch for a version supporting pytorch1.0! Just go to the [py
 | Frequency \[1\]                |  VGG16            | 17.7     | 23.5     | 27.6      |
 | Frequency+Overlap \[1\]        |  VGG16            | 20.1     | 26.2     | 30.1      |
 | MotifNet \[1\]                 |  VGG16            | 21.4     | 27.2     | 30.3      |
-| Graph-RCNN \[2\]               |  Res-101          | 19.4	    | 25.0     |	28.5      |
+| Graph-RCNN \[2\]               |  Res-101          | 18.8	    | 23.7     |	26.2      |
 | RelDN, w/o contrastive losses  |  VGG16            | 20.8     | 28.1     | 32.5      |
 | RelDN, full                    |  VGG16            | 21.1     | 28.3     | 32.7      |
 | RelDN, full                    |  ResNext-101-FPN  | 22.5     | 31.0     | 36.7      |


### PR DESCRIPTION
Results of "Graph-RCNN" are directly copied **by mistake** from [their repo](https://github.com/jwyang/graph-rcnn.pytorch). Please note that the reported numbers of the replication of Frequency Prior of Neural Motifs with a different backbone (ResNet). The actual numbers of Graph R-CNN can be found under "Comparisons with other Methods" last row (the attentional vesion is not implemented yet).